### PR TITLE
Fix JXA build & syntax

### DIFF
--- a/AppleScript.sublime-build
+++ b/AppleScript.sublime-build
@@ -7,8 +7,6 @@
   "osx": {
     "cmd": [
       "/usr/bin/osacompile",
-      "-l",
-      "JavaScript",
       "-o",
       "$file_base_name.scpt",
       "$file"
@@ -20,8 +18,6 @@
       "osx": {
         "cmd": [
           "/usr/bin/osacompile",
-          "-l",
-          "JavaScript",
           "-o",
           "$file_base_name.scptd",
           "$file"
@@ -33,8 +29,6 @@
       "osx": {
         "cmd": [
           "/usr/bin/osacompile",
-          "-l",
-          "JavaScript",
           "-o",
           "$file_base_name.app",
           "$file"
@@ -46,8 +40,6 @@
       "osx": {
         "cmd": [
           "/usr/bin/osascript",
-          "-l",
-          "JavaScript",
           "$file"
         ]
       }

--- a/JavaScript for Automation (JXA).sublime-build
+++ b/JavaScript for Automation (JXA).sublime-build
@@ -7,6 +7,8 @@
   "osx": {
     "cmd": [
       "/usr/bin/osacompile",
+      "-l",
+      "JavaScript",
       "-o",
       "$file_base_name.scpt",
       "$file"
@@ -18,6 +20,8 @@
       "osx": {
         "cmd": [
           "/usr/bin/osacompile",
+          "-l",
+          "JavaScript",
           "-o",
           "$file_base_name.scptd",
           "$file"
@@ -29,6 +33,8 @@
       "osx": {
         "cmd": [
           "/usr/bin/osacompile",
+          "-l",
+          "JavaScript",
           "-o",
           "$file_base_name.app",
           "$file"
@@ -40,6 +46,8 @@
       "osx": {
         "cmd": [
           "/usr/bin/osascript",
+          "-l",
+          "JavaScript",
           "$file"
         ]
       }

--- a/JavaScript for Automation (JXA).sublime-syntax
+++ b/JavaScript for Automation (JXA).sublime-syntax
@@ -10,4 +10,4 @@ file_extensions:
 scope: source.js.jxa
 contexts:
   main:
-    - include: scope:source.js.jxa
+    - include: scope:source.js


### PR DESCRIPTION
The build system for JXA didn't specify JavaScript as language so it
tried to run jxa files in the normal applescript mode.

Also fixed the JXA syntax import to point to the js syntax instead of
itself